### PR TITLE
建物生成の判定処理

### DIFF
--- a/Runtime/Scripts/BuildingCreator.cs
+++ b/Runtime/Scripts/BuildingCreator.cs
@@ -20,7 +20,7 @@ namespace PolygonGenerator
 			maxHeight = max;
 		}
 
-		public IEnumerator CreateBuildingMesh(List<SurroundedArea> areas)
+		public IEnumerator CreateBuildingMesh(List<SurroundedArea> areas, float areaSize, float sideRatio)
 		{
 			var parameters = new List<BuildingParameter>();
 			var types = new BuildingParameter.BuildingType[]
@@ -37,15 +37,51 @@ namespace PolygonGenerator
 					points.Add(points[2]);
 				}
 
-				var param = new BuildingParameter(points);
-				param.SetBuildingType(types[random.Next(types.Length)], random.Next(4));
-				param.SetBuildingHeight(Mathf.Lerp(minHeight, maxHeight, (float)random.NextDouble()));
-				parameters.Add(param);
+				if (CanBuildBuilding(points, areaSize, sideRatio) != false)
+				{
+					var param = new BuildingParameter(points);
+					param.SetBuildingType(types[random.Next(types.Length)], random.Next(4));
+					param.SetBuildingHeight(Mathf.Lerp(minHeight, maxHeight, (float)random.NextDouble()));
+					parameters.Add(param);
+				}
 			}
 
 			meshCreator.BuildingPolygonCreate(parameters);
 
 			yield break;
+		}
+
+		bool CanBuildBuilding(List<Vector3> points, float areaSize, float sideRatio)
+		{
+			bool canBuild = true;
+
+			Vector3 v1 = points[1] - points[0];
+			Vector3 v2 = points[2] - points[1];
+			Vector3 v3 = points[3] - points[2];
+			Vector3 v4 = points[0] - points[3];
+
+			float s = (Mathf.Abs(Vector3.Cross(v1, v2).y) + Mathf.Abs(Vector3.Cross(v3, v4).y)) * 0.5f;
+			if (s < areaSize || (CalcRatio(v1, v3) >= sideRatio && CalcRatio(v2, v4) >= sideRatio))
+			{
+				canBuild = false;
+			}
+
+			return canBuild;
+		}
+
+		float CalcRatio(Vector3 v1, Vector3 v2)
+		{
+			float ratio = Mathf.Infinity;
+
+			float m1 = v1.magnitude;
+			float m2 = v2.magnitude;
+
+			if (Mathf.Approximately(m1, 0) == false && Mathf.Approximately(m2, 0) == false)
+			{
+				ratio = m1 > m2 ? m1 / m2 : m2 / m1;
+			}
+
+			return ratio;
 		}
 
 		System.Random random;

--- a/Runtime/Scripts/LinePolygonCreator.cs
+++ b/Runtime/Scripts/LinePolygonCreator.cs
@@ -56,6 +56,7 @@ namespace PolygonGenerator
 		void CreateMeshParameter(List<FieldConnectPoint> points, float width, float uvY1, float uvY2)
 		{
 			vertices.Clear();
+			uvs.Clear();
 			indices.Clear();
 			connectedMap.Clear();
 			float halfWidth = width * 0.5f;


### PR DESCRIPTION
エリアの面積が小さいもしくは辺の比率が一定以上の場合、建物を生成しないよう変更。
CreateBuildingMesh()に面積と比率を指定します。
LinePolygonCreator内でuvのリストをクリアしていなかったので修正。