### PR TITLE
凹面体のエリアに建物が生成されないよう修正

### DIFF
--- a/Runtime/Scripts/BuildingCondition.cs
+++ b/Runtime/Scripts/BuildingCondition.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FieldGenerator;
+
+namespace PolygonGenerator
+{
+	[System.Serializable]
+	public class BuildingCondition
+	{
+		[SerializeField]
+		public float minAreaSize = 120;
+		[SerializeField]
+		public float sideRatio = 3;
+		[SerializeField]
+		public float minAngle = 0;
+		[SerializeField]
+		public float maxAngle = 360;
+	}
+}

--- a/Runtime/Scripts/BuildingCondition.cs.meta
+++ b/Runtime/Scripts/BuildingCondition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 205d5990cf6508e4fa612434bf4e1120
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
建物を生成する際に凹面体のエリアには生成されないよう修正しました。
エリアの最小と最大の角度を設定し、小さすぎるまたは大きすぎる角度がある場合
建物を生成しないよう変更しました。
建物生成の条件を表すクラスを追加しました。
建物の生成に必要なエリアの最小面積、辺の比率、角度の最小と最大を設定します。