### PR TITLE
ポリゴン生成時に幅を候補の中から抽選で決定できるよう変更

### DIFF
--- a/Runtime/Scripts/LinePolygonCreator.cs
+++ b/Runtime/Scripts/LinePolygonCreator.cs
@@ -14,17 +14,27 @@ namespace PolygonGenerator
 			meshFilter = gameObject?.GetComponent<MeshFilter>();
 		}
 
-		public IEnumerator CreatePolygon(List<FieldConnectPoint> points, float width, float uvY1, float uvY2, float disconnectionProb = 0)
+		public IEnumerator CreatePolygon(List<FieldConnectPoint> points, WeightedValue[] widthCandidates, float uvY1, float uvY2, float disconnectionProb = 0)
 		{
 			if (meshFilter != null)
 			{
 				lastInterruptionTime = System.DateTime.Now;
-
-				this.width = width;
+				this.widthCandidates = widthCandidates;
 				Prepare(points);
-				yield return CoroutineUtility.CoroutineCycle( CreateMeshParameter(points, width, uvY1, uvY2, disconnectionProb));
+				yield return CoroutineUtility.CoroutineCycle( CreateMeshParameter(points, uvY1, uvY2, disconnectionProb));
 				meshFilter.sharedMesh = CreateMesh();
 			}
+		}
+
+		public IEnumerator CreatePolygon(List<FieldConnectPoint> points, float width, float uvY1, float uvY2, float disconnectionProb = 0)
+		{
+			var candidates = new WeightedValue[] { new WeightedValue { value = width, weight = 1 } };
+			yield return CoroutineUtility.CoroutineCycle(CreatePolygon(points, candidates, uvY1, uvY2, disconnectionProb));
+		}
+
+		public IEnumerator CreatePolygon(List<FieldConnectPoint> points, WeightedValue[] widthCandidates)
+		{
+			yield return CoroutineUtility.CoroutineCycle( CreatePolygon(points, widthCandidates, 0, 1, 0));
 		}
 
 		public IEnumerator CreatePolygon(List<FieldConnectPoint> points, float width)
@@ -69,8 +79,16 @@ namespace PolygonGenerator
 				}
 			}
 
-			/* 道路の幅が狭い方を多く生成させたかったので、ちょっと改造してあります（玉城） */
-			float[] widthCand = { width, width * 0.75f, width * 0.75f, width * 0.5f, width * 0.5f, width * 0.5f, width * 0.5f, width * 0.25f, width * 0.25f, width * 0.25f };
+			maxWidth = 0;
+			for (int i0 = 0; i0 < widthCandidates.Length; ++i0)
+			{
+				float width = widthCandidates[i0].value;
+				if (width > maxWidth)
+				{
+					maxWidth = width;
+				}
+			}
+
 			for (int i0 = 0; i0 < points.Count; ++i0)
 			{
 				FieldConnectPoint point= points[i0];
@@ -84,7 +102,7 @@ namespace PolygonGenerator
 					float width;
 					if (widthMap.TryGetValue(key1, out width) == false)
 					{
-						width = widthCand[(point.Type != PointType.kRiver ? random.Next(10) : 0)];
+						width = DetectWeightedValue(widthCandidates);
 						widthMap.Add(key1, width);
 						widthMap.Add(key2, width);
 					}
@@ -93,7 +111,7 @@ namespace PolygonGenerator
 			}
 		}
 
-		IEnumerator CreateMeshParameter(List<FieldConnectPoint> points, float width, float uvY1, float uvY2, float disconnectionProb)
+		IEnumerator CreateMeshParameter(List<FieldConnectPoint> points, float uvY1, float uvY2, float disconnectionProb)
 		{
 			vertices.Clear();
 			uvs.Clear();
@@ -101,7 +119,7 @@ namespace PolygonGenerator
 			indicesMap.Clear();
 			judgedCombinationSet.Clear();
 			disconnectCombinationSet.Clear();
-			// float halfWidth = width * 0.5f;
+
 			for (int i0 = 0; i0 < points.Count; ++i0)
 			{
 				FieldConnectPoint point = points[i0];
@@ -234,7 +252,7 @@ namespace PolygonGenerator
 							}
 
 							Vector3 dist = intersection - point.Position;
-							float maxDist = width * 3;
+							float maxDist = maxWidth * 3;
 							if (dist.sqrMagnitude > maxDist * maxDist)
 							{
 								intersection = (r1 + l1) * 0.5f;
@@ -393,12 +411,6 @@ namespace PolygonGenerator
 			return isIntersecting;
 		}
 
-		void AddJudgedCombination(int index1, int index2)
-		{
-			judgedCombinationSet.Add(new Vector2Int(index1, index2));
-			judgedCombinationSet.Add(new Vector2Int(index2, index1));
-		}
-
 		bool DetectFromPercent(float percent)
 		{
 			int numDigit = 0;
@@ -413,6 +425,36 @@ namespace PolygonGenerator
 			int border = (int)(percent * rate);
 
 			return random.Next(0, maxValue) < border;
+		}
+
+		float DetectWeightedValue(WeightedValue[] candidates)
+		{
+			float value = 0;
+
+			float totalWeight = 0;
+			for (int i0 = 0; i0 < candidates.Length; ++i0)
+			{
+				totalWeight += candidates[i0].weight;
+			}
+
+			float border = totalWeight * (float)random.NextDouble();
+
+			for (int i0 = 0; i0 < candidates.Length; ++i0)
+			{
+				float weight = candidates[i0].weight;
+				if (Mathf.Approximately(weight, 0) == false)
+				{
+					if (border <= weight)
+					{
+						value = candidates[i0].value;
+						break;
+					}
+				}
+
+				border -= weight;
+			}
+
+			return value;
 		}
 
 
@@ -433,6 +475,7 @@ namespace PolygonGenerator
 		Dictionary<int, int> connectCountMap = new Dictionary<int, int>();
 		Dictionary<Vector2Int, float> widthMap = new Dictionary<Vector2Int, float>();
 
-		float width;
+		WeightedValue[] widthCandidates;
+		float maxWidth;
 	}
 }


### PR DESCRIPTION
CreatePolygon()の第二引数にWeightedValueの配列を渡すとその中から重み付きの抽選で道路の幅を決定します。
floatの値を渡した場合はすべてその値の幅で生成されます。