### PR TITLE
建物の高さの抽選方法変更

### DIFF
--- a/Runtime/Scripts/BuildingCondition.cs
+++ b/Runtime/Scripts/BuildingCondition.cs
@@ -17,6 +17,6 @@ namespace PolygonGenerator
 		[SerializeField]
 		public float maxAngle = 360;
 		[SerializeField]
-		public WeightedRange[] ranges = default;
+		public WeightedRange[] heightRanges = default;
 	}
 }

--- a/Runtime/Scripts/BuildingCondition.cs
+++ b/Runtime/Scripts/BuildingCondition.cs
@@ -16,5 +16,7 @@ namespace PolygonGenerator
 		public float minAngle = 0;
 		[SerializeField]
 		public float maxAngle = 360;
+		[SerializeField]
+		public WeightedRange[] ranges = default;
 	}
 }

--- a/Runtime/Scripts/BuildingCreator.cs
+++ b/Runtime/Scripts/BuildingCreator.cs
@@ -14,12 +14,6 @@ namespace PolygonGenerator
 			this.meshCreator = meshCreator;
 		}
 
-		public void SetHeightRange(float min, float max)
-		{
-			minHeight = min;
-			maxHeight = max;
-		}
-
 		public IEnumerator CreateBuildingMesh(List<SurroundedArea> areas, BuildingCondition condition, float generationRate)
 		{
 			lastInterruptionTime = System.DateTime.Now;
@@ -54,6 +48,8 @@ namespace PolygonGenerator
 				int randomIndex = random.Next(count);
 				var param = new BuildingParameter(buildableAreas[randomIndex].AreaPoints);
 				param.SetBuildingType(types[random.Next(types.Length)], random.Next(4));
+				float minHeight, maxHeight;
+				DetectRange(condition.ranges, out minHeight, out maxHeight);
 				param.SetBuildingHeight(Mathf.Lerp(minHeight, maxHeight, (float)random.NextDouble()));
 				parameters.Add(param);
 
@@ -90,6 +86,37 @@ namespace PolygonGenerator
 				{
 					yield return null;
 					lastInterruptionTime = System.DateTime.Now;
+				}
+			}
+		}
+
+		void DetectRange(WeightedRange[] ranges, out float min, out float max)
+		{
+			min = 0;
+			max = 0;
+
+			float totalWeight = 0;
+			for (int i0 = 0; i0 < ranges.Length; ++i0)
+			{
+				totalWeight += ranges[i0].weight;
+			}
+
+			float border = totalWeight * (float)random.NextDouble();
+
+			for (int i0 = 0; i0 < ranges.Length; ++i0)
+			{
+				WeightedRange range = ranges[i0];
+				float weight = range.weight;
+				if (Mathf.Approximately(weight, 0) == false)
+				{
+					if (border <= weight)
+					{
+						min = range.min;
+						max = range.max;
+						break;
+					}
+
+					border -= weight;
 				}
 			}
 		}
@@ -198,7 +225,5 @@ namespace PolygonGenerator
 		System.Random random;
 		System.DateTime lastInterruptionTime;
 		MeshCreator meshCreator;
-		float minHeight;
-		float maxHeight;
 	}
 }

--- a/Runtime/Scripts/BuildingCreator.cs
+++ b/Runtime/Scripts/BuildingCreator.cs
@@ -49,7 +49,7 @@ namespace PolygonGenerator
 				var param = new BuildingParameter(buildableAreas[randomIndex].AreaPoints);
 				param.SetBuildingType(types[random.Next(types.Length)], random.Next(4));
 				float minHeight, maxHeight;
-				DetectRange(condition.ranges, out minHeight, out maxHeight);
+				DetectRange(condition.heightRanges, out minHeight, out maxHeight);
 				param.SetBuildingHeight(Mathf.Lerp(minHeight, maxHeight, (float)random.NextDouble()));
 				parameters.Add(param);
 

--- a/Runtime/Scripts/BuildingCreator.cs
+++ b/Runtime/Scripts/BuildingCreator.cs
@@ -14,6 +14,11 @@ namespace PolygonGenerator
 			this.meshCreator = meshCreator;
 		}
 
+		//↓高さの設定方を変更したため、削除予定です
+		public void SetHeightRange(float min, float max)
+		{
+		}
+
 		public IEnumerator CreateBuildingMesh(List<SurroundedArea> areas, BuildingCondition condition, float generationRate)
 		{
 			lastInterruptionTime = System.DateTime.Now;


### PR DESCRIPTION
BuildingConditionに重み付き範囲を表すクラスWeightedRangeの配列を追加し、その中から選ばれた範囲内の高さの建物を生成するよう変更しました。
SetHeightRange()を使用しないようにしました。削除予定です。