### PR TITLE
indexFormatを32ビットに変更

### DIFF
--- a/Runtime/Scripts/LinePolygonCreator.cs
+++ b/Runtime/Scripts/LinePolygonCreator.cs
@@ -45,6 +45,7 @@ namespace PolygonGenerator
 		Mesh CreateMesh()
 		{
 			var mesh = new Mesh();
+			mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
 			mesh.SetVertices(vertices);
 			mesh.SetUVs(0, uvs);
 			mesh.SetTriangles(indices, 0);


### PR DESCRIPTION
ポリゴン生成時にMesh.indexFormatを32ビットに変更し、頂点数の上限を引き上げました。